### PR TITLE
Develop

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GH_PAT_TOKEN }}
 
       - name: Extract metadata
         id: meta

--- a/.github/workflows/merge-develop-to-main.yml
+++ b/.github/workflows/merge-develop-to-main.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         ref: develop
         fetch-depth: 0
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.GH_PAT_TOKEN }}
 
     - name: Configure git
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  packages: write
+  security-events: write
 
 jobs:
   create-release:
@@ -61,7 +63,7 @@ jobs:
         id: create_release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_TOKEN }}
         with:
           tag_name: ${{ steps.version.outputs.version }}
           release_name: Release ${{ steps.version.outputs.version }}
@@ -181,7 +183,7 @@ jobs:
           cd checksums
           
           # Get all release assets
-          curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          curl -H "Authorization: token ${{ secrets.GH_PAT_TOKEN }}" \
                -H "Accept: application/vnd.github.v3+json" \
                https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ needs.create-release.outputs.version }} | \
                jq -r '.assets[] | select(.name | test("\\.(tar\\.gz|zip)$")) | .browser_download_url' | \
@@ -196,7 +198,7 @@ jobs:
       - name: Upload checksums
         uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_TOKEN }}
         with:
           upload_url: ${{ needs.create-release.outputs.upload_url }}
           asset_path: checksums/checksums.txt
@@ -219,7 +221,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GH_PAT_TOKEN }}
 
       - name: Extract metadata
         id: meta

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,12 +77,12 @@ jobs:
             
             ### Using Go
             ```bash
-            go install github.com/italoag/ghcloner/cmd/ghclone@${{ steps.version.outputs.version }}
+            go install github.com/italoag/bloco-wallet/cmd/blocowallet@${{ steps.version.outputs.version }}
             ```
             
             ### Docker
             ```bash
-            docker pull ghcr.io/italoag/ghclone:${{ steps.version.outputs.version }}
+            docker pull ghcr.io/italoag/bloco-wallet:${{ steps.version.outputs.version }}
             ```
             
             ## Verification
@@ -126,7 +126,7 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: 0
         run: |
-          export BINARY_NAME=ghclone
+          export BINARY_NAME=blocowallet
           if [ "$GOOS" = "windows" ]; then
             export BINARY_NAME="${BINARY_NAME}.exe"
           fi
@@ -136,18 +136,18 @@ jobs:
           go build \
             -ldflags="-w -s -X main.version=${{ needs.create-release.outputs.version }} -X main.commit=${{ github.sha }} -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             -o dist/${BINARY_NAME} \
-            ./cmd/ghclone
+            ./cmd/blocowallet
 
       - name: Create archive
         run: |
           cd dist
-          BINARY_NAME=ghclone
+          BINARY_NAME=blocowallet
           if [ "${{ matrix.goos }}" = "windows" ]; then
             BINARY_NAME="${BINARY_NAME}.exe"
-            ARCHIVE_NAME="ghclone-${{ needs.create-release.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}.zip"
+            ARCHIVE_NAME="blocowallet-${{ needs.create-release.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}.zip"
             zip "${ARCHIVE_NAME}" "${BINARY_NAME}"
           else
-            ARCHIVE_NAME="ghclone-${{ needs.create-release.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz"
+            ARCHIVE_NAME="blocowallet-${{ needs.create-release.outputs.version }}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz"
             tar -czf "${ARCHIVE_NAME}" "${BINARY_NAME}"
           fi
           echo "ARCHIVE_NAME=${ARCHIVE_NAME}" >> $GITHUB_ENV
@@ -225,7 +225,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/ghclone
+          images: ghcr.io/${{ github.repository_owner }}/bloco-wallet
           tags: |
             type=ref,event=tag
             type=semver,pattern={{version}}


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to improve security and reflect a project rename from `ghclone` to `bloco-wallet`. The most significant changes are the switch to a more secure GitHub token for all privileged operations and the thorough renaming of build, release, and packaging steps to use the new project name.

**Security and authentication improvements:**

* All workflows now use `${{ secrets.GH_PAT_TOKEN }}` instead of `${{ secrets.GITHUB_TOKEN }}` for authentication with GitHub APIs and registry operations, which is generally more secure and provides finer-grained permissions. (.github/workflows/container.yml [[1]](diffhunk://#diff-87249919b62f3d7f70416176a4254d5df6e59eab47c6de2a2a4fbbcf4138cbacL39-R39) .github/workflows/merge-develop-to-main.yml [[2]](diffhunk://#diff-13b20c79ad7c6b3c239ea1a3b888fe72a4c4c58694f51325274140573c399574L26-R26) .github/workflows/release.yml [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L64-R66) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L184-R186) [[5]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L199-R201) [[6]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L222-R230)

**Project rename and build/release updates:**

* All references to the binary, Docker image, and build paths have been updated from `ghclone` to `bloco-wallet` in the release workflow, including build commands, archive names, and Docker image tags. (.github/workflows/release.yml [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L80-R87) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L129-R131) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L139-R152) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L222-R230)
* The Go build and archive steps now use `blocowallet` as the binary name and update the archive names to match the new project name. (.github/workflows/release.yml [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L129-R131) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L139-R152)

**Workflow permissions:**

* The release workflow has been updated to grant additional permissions for writing to packages and security events, which may be required for publishing and reporting. (.github/workflows/release.yml [.github/workflows/release.ymlR20-R21](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R20-R21))

**Documentation and usage instructions:**

* The usage instructions in the release workflow now reference the new Go module and Docker image for `bloco-wallet`. (.github/workflows/release.yml [.github/workflows/release.ymlL80-R87](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L80-R87))

These changes ensure that the workflows are secure and aligned with the new project identity.