### PR TITLE
Enhance version-bump workflow: detect patch/minor bump based

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -45,9 +45,13 @@ jobs:
             minor=0
             patch=0
           fi
-          if jq -e '.pull_request.labels | any(.name | test("hotfix"; "i"))' "$GITHUB_EVENT_PATH" > /dev/null; then
+          src_branch=$(jq -r '.pull_request.head.ref' "$GITHUB_EVENT_PATH")
+          echo "Source branch: $src_branch"
+          if [[ "$src_branch" =~ ^(hotfix|bugfix)/ ]]; then
+            # hotfix/* or bugfix/* => patch bump
             patch=$((patch+1))
           else
+            # feature/* and others (default) => minor bump
             minor=$((minor+1))
             patch=0
           fi


### PR DESCRIPTION
…e branch type
This pull request updates the version bump logic in the `.github/workflows/version-bump.yml` workflow to determine the type of version bump based on the source branch name rather than pull request labels.

Version bump logic improvements:

* The workflow now checks if the source branch name starts with `hotfix/` or `bugfix/` to trigger a patch version bump, instead of relying on the presence of a `hotfix` label on the pull request.
* For all other branch naming patterns (such as `feature/*`), the workflow triggers a minor version bump by default.